### PR TITLE
Use ProjectUsing

### DIFF
--- a/Sample03/AutoMapperConfig/PersianExtensions.cs
+++ b/Sample03/AutoMapperConfig/PersianExtensions.cs
@@ -5,7 +5,7 @@ namespace Sample03.AutoMapperConfig
 {
     public static class PersianExtensions
     {
-        public static string ToShamsiDateTime(this DateTime info, string separator = "/", bool includeHourMinute = true)
+        public static string ToShamsiDateTime(this DateTime info)
         {
             var year = info.Year;
             var month = info.Month;
@@ -14,9 +14,7 @@ namespace Sample03.AutoMapperConfig
             var pYear = persianCalendar.GetYear(new DateTime(year, month, day, new GregorianCalendar()));
             var pMonth = persianCalendar.GetMonth(new DateTime(year, month, day, new GregorianCalendar()));
             var pDay = persianCalendar.GetDayOfMonth(new DateTime(year, month, day, new GregorianCalendar()));
-            return includeHourMinute ?
-                string.Format("{0}{1}{2}{1}{3} {4}:{5}", pYear, separator, pMonth.ToString("00", CultureInfo.InvariantCulture), pDay.ToString("00", CultureInfo.InvariantCulture), info.Hour.ToString("00"), info.Minute.ToString("00"))
-                : string.Format("{0}{1}{2}{1}{3}", pYear, separator, pMonth.ToString("00", CultureInfo.InvariantCulture), pDay.ToString("00", CultureInfo.InvariantCulture));
+            return string.Format("{0}{1}{2}{1}{3}", pYear, "/", pMonth.ToString("00", CultureInfo.InvariantCulture), pDay.ToString("00", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Sample03/AutoMapperConfig/TestProfile.cs
+++ b/Sample03/AutoMapperConfig/TestProfile.cs
@@ -8,12 +8,12 @@ namespace Sample03.AutoMapperConfig
         protected override void Configure()
         {
             this.CreateMap<User, UserViewModel>()
-                .ForMember(userViewModel => userViewModel.RegistrationDate,
-                        opt => opt.ResolveUsing(src =>
-                        {
-                            var dt = src.RegistrationDate;
-                            return dt.ToShamsiDateTime();
-                        }));
+                .ProjectUsing(src => new UserViewModel
+                {
+                    Id = src.Id,
+                    Name = src.Name,
+                    RegistrationDate = src.RegistrationDate.ToShamsiDateTime()
+                });
         }
     }
 }

--- a/Sample03/Program.cs
+++ b/Sample03/Program.cs
@@ -9,14 +9,16 @@ namespace Sample03
         static void Main(string[] args)
         {
             var usersService = SmObjectFactory.Container.GetInstance<IUsersService>();
-            var user1 = usersService.GetName(id: 1);
-            Console.WriteLine("{0}", user1.RegistrationDate);
+            /*var user1 = usersService.GetName(id: 1);
+            Console.WriteLine("{0}", user1.RegistrationDate);*/
 
-            //var users = usersService.GetUsersList();
-            //foreach (var user in users)
-            //{
-            //    Console.WriteLine("{0}", user.Name);
-            //}
+            var users = usersService.GetUsersList();
+            foreach (var user in users)
+            {
+                Console.WriteLine("{0} - {1}", user.Name, user.RegistrationDate);
+            }
+
+            Console.ReadKey();
         }
     }
 }


### PR DESCRIPTION
[This piece of code](https://github.com/VahidN/AutoMapperSamples/blob/master/Sample03/Services/UsersService.cs#L46-L48) doesn't work properly when calling `GetUsersList`. It throws this exception:

> Can't resolve this to Queryable Expression

The problem is Projections, So for solving this problem we have to change these lines of code:

```
this.CreateMap<User, UserViewModel>()
                .ForMember(userViewModel => userViewModel.RegistrationDate,
                        opt => opt.ResolveUsing(src =>
                        {
                            var dt = src.RegistrationDate;
                            return dt.ToShamsiDateTime();
                        }));
```

To this:

```
this.CreateMap<User, UserViewModel>()
                    .ProjectUsing(src => new UserViewModel
                        {
                            Id = src.Id,
                            Name = src.Name,
                            RegistrationDate = src.RegistrationDate.ToShamsiDateTime()
                        });
```

**PS:**  Since the underlying expression tree API does not support optional arguments, We have to remove optional parameters from the `ToShamsiDateTime()`.
